### PR TITLE
*: repoint go import path to flatcar-linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 VERSION=$(shell git describe --dirty)
-REPO=github.com/coreos/locksmith
+REPO=github.com/flatcar-linux/locksmith
 LD_FLAGS="-w -s -extldflags -static"
 
 export GOPATH=$(shell pwd)/gopath
@@ -19,7 +19,7 @@ export GOPATH=$(shell pwd)/gopath
 all: bin/locksmithctl
 
 gopath:
-	$(Q)mkdir -p gopath/src/github.com/coreos
+	$(Q)mkdir -p gopath/src/github.com/flatcar-linux
 	$(Q)ln -s ../../../.. gopath/src/$(REPO)
 
 GO_SOURCES := $(shell find . -type f -name "*.go")

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/coreos/locksmith
+package: github.com/flatcar-linux/locksmith
 import:
 - package: github.com/coreos/etcd
   version: v2.2.5

--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -30,11 +30,11 @@ import (
 	"github.com/coreos/go-systemd/login1"
 	"github.com/coreos/pkg/capnslog"
 
-	"github.com/coreos/locksmith/lock"
-	"github.com/coreos/locksmith/pkg/coordinatorconf"
-	"github.com/coreos/locksmith/pkg/machineid"
-	"github.com/coreos/locksmith/pkg/timeutil"
-	"github.com/coreos/locksmith/updateengine"
+	"github.com/flatcar-linux/locksmith/lock"
+	"github.com/flatcar-linux/locksmith/pkg/coordinatorconf"
+	"github.com/flatcar-linux/locksmith/pkg/machineid"
+	"github.com/flatcar-linux/locksmith/pkg/timeutil"
+	"github.com/flatcar-linux/locksmith/updateengine"
 )
 
 const (
@@ -47,7 +47,7 @@ const (
 
 var (
 	// TODO(mischief): daemon is not really a seperate package. it probably should be.
-	dlog = capnslog.NewPackageLogger("github.com/coreos/locksmith", "daemon")
+	dlog = capnslog.NewPackageLogger("github.com/flatcar-linux/locksmith", "daemon")
 )
 
 const (

--- a/locksmithctl/help.go
+++ b/locksmithctl/help.go
@@ -17,7 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/coreos/locksmith/version"
+	"github.com/flatcar-linux/locksmith/version"
 	"os"
 	"strings"
 	"text/template"

--- a/locksmithctl/lock.go
+++ b/locksmithctl/lock.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coreos/locksmith/lock"
-	"github.com/coreos/locksmith/pkg/machineid"
+	"github.com/flatcar-linux/locksmith/lock"
+	"github.com/flatcar-linux/locksmith/pkg/machineid"
 )
 
 var (

--- a/locksmithctl/locksmithctl.go
+++ b/locksmithctl/locksmithctl.go
@@ -28,8 +28,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/coreos/locksmith/lock"
-	"github.com/coreos/locksmith/version"
+	"github.com/flatcar-linux/locksmith/lock"
+	"github.com/flatcar-linux/locksmith/version"
 
 	"github.com/coreos/etcd/client"
 )

--- a/locksmithctl/reboot.go
+++ b/locksmithctl/reboot.go
@@ -19,8 +19,8 @@ import (
 	"os"
 
 	"github.com/coreos/go-systemd/login1"
-	"github.com/coreos/locksmith/lock"
-	"github.com/coreos/locksmith/pkg/machineid"
+	"github.com/flatcar-linux/locksmith/lock"
+	"github.com/flatcar-linux/locksmith/pkg/machineid"
 )
 
 var (

--- a/locksmithctl/set_max.go
+++ b/locksmithctl/set_max.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/coreos/locksmith/lock"
+	"github.com/flatcar-linux/locksmith/lock"
 )
 
 var (

--- a/locksmithctl/status.go
+++ b/locksmithctl/status.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coreos/locksmith/lock"
+	"github.com/flatcar-linux/locksmith/lock"
 )
 
 var (

--- a/locksmithctl/unlock.go
+++ b/locksmithctl/unlock.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coreos/locksmith/lock"
-	"github.com/coreos/locksmith/pkg/machineid"
+	"github.com/flatcar-linux/locksmith/lock"
+	"github.com/flatcar-linux/locksmith/pkg/machineid"
 )
 
 var (

--- a/pkg/coordinatorconf/conf.go
+++ b/pkg/coordinatorconf/conf.go
@@ -33,7 +33,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/coreos/locksmith/pkg/filelock"
+	"github.com/flatcar-linux/locksmith/pkg/filelock"
 )
 
 const UpdateCoordinatorConfPath = "/run/update-engine/coordinator.conf"


### PR DESCRIPTION
To ensure this repo is building from itself, and not relying on a
directory path work-around.

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# point the import path this repo


# How to use

clone the repo, run `make`, ensure you have `./bin/locksmithctl`


# Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
