### PR TITLE
locksmithcl: reset `endpoints` when we set a new one

### DIFF
--- a/locksmithctl/locksmithctl.go
+++ b/locksmithctl/locksmithctl.go
@@ -76,6 +76,7 @@ func (e *endpoints) String() string {
 }
 
 func (e *endpoints) Set(value string) error {
+	*e = []string{}
 	for _, url := range strings.Split(value, ",") {
 		*e = append(*e, strings.TrimSpace(url))
 	}


### PR DESCRIPTION
This behavior was working fine previously but no more with the etcd/v2
upgrade.

In the case we have an endpoint like `https://127.0.0.1:2379`, this one
will be _added_ to the list of `defaultEndpoints` which lead to this
endpoints:
```go
[]string{
	"http://127.0.0.1:2379",
	"http://127.0.0.1:4001",
	"https://127.0.0.1:2379",
}
```

It's not an issue when we have a retry mechanism - but in this case if
`etcd` use HTTPS and we try an `HTTP` endpoint, we will get an io.EOF
error.

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

---

Otherwise, we could just do this:
```diff
                if err != nil {
-                       if errors.Is(err, syscall.ECONNREFUSED) {
+                       if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, io.EOF) {
                                continue
                        }
```

but, as a user, I would expect that if I run `locksmithctl -endpoint https://127.0.0.1:2379` I would run locksmithcl only against this endpoint, not a bundle of `defautEndpoints + endpoint`.

This issue has been caught by the CI with the `coreos.locksmith.tls` - I will rerun the kola tests before merging this one.
