### PR TITLE
Stop using deprecated resource control options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 ### Added
 ### Changed
+- Replace deprecated CPUShares and MemoryLimit control options in the systemd unit with CPUWeight and MemoryHigh ([#20](https://github.com/flatcar/locksmith/pull/20))
+
 ### Removed
 
 ## [v0.7.0](https://github.com/flatcar/locksmith/releases/tag/v0.7.0)- 30/11/2021

--- a/systemd/locksmithd.service
+++ b/systemd/locksmithd.service
@@ -5,8 +5,8 @@ ConditionVirtualization=!container
 ConditionPathExists=!/usr/.noupdate
 
 [Service]
-CPUShares=16
-MemoryLimit=32M
+CPUWeight=10
+MemoryHigh=32M
 
 # Locksmith requires access to /dev/tty(S)* and /dev/pts/*
 PrivateDevices=false


### PR DESCRIPTION
`CPUShares` and `MemoryLimit` were related to the legacy cgroup hierachies, that systemd will shortly stop supporting. Right now, systemd 252 prints warnings if those are used.

Use related features for unified cgroup hierarchies.

- [x] changelog

Closes: https://github.com/flatcar/Flatcar/issues/981