### PR TITLE
systemd: Restore access to TTYs for reboot delay

### DIFF
--- a/systemd/locksmithd.service
+++ b/systemd/locksmithd.service
@@ -7,7 +7,10 @@ ConditionPathExists=!/usr/.noupdate
 [Service]
 CPUShares=16
 MemoryLimit=32M
-PrivateDevices=true
+
+# Locksmith requires access to /dev/tty(S)* and /dev/pts/*
+PrivateDevices=false
+
 Environment=GOMAXPROCS=1
 EnvironmentFile=-/usr/share/flatcar/update.conf
 EnvironmentFile=-/etc/flatcar/update.conf


### PR DESCRIPTION
When sessions are active, locksmith write a message to the TTYs of the sessions and then delays the reboot for 5 minutes to give the user time to stop the reboot or finish the work.
The commit for cgroup memory and CPU limits also brought in a change to disallow /dev/tty* access which broke the delay for console users except SSH sessions which are under /dev/pts/*.
Allow device access to have a delay of 5 minutes when sessions are active. This includes the autologin session even if no interaction was done there recently. Still, the reboot delay doesn't hurt and since update-engine has a random delay for pulling updates, there is no big difference in the end.


## How to use

Update ref in ebuild

## Testing done

In the demo @tormath1 prepared, locksmith didn't wait. We looked at the possible issue and found this.
I just tried `echo A >> /dev/tty1` with `sudo systemd-run -S -P --property=PrivateDevices=true -G` and it failed while it works with `PrivateDevices=false`, so I think this will fix the issue. @tormath1 did a test with `PrivateDevices=true` removed and the delay worked.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
