### PR TITLE
drop kinvolk references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ contribution. See the [DCO](DCO) file for details.
 
 # Email and Chat
 
-Read [Participate and contribute](https://github.com/kinvolk/flatcar#participate-and-contribute)
+Read [Participate and contribute](https://github.com/flatcar/flatcar#participate-and-contribute)
 for mailing list and matrix chat information.
 
 Please avoid emailing maintainers found in the MAINTAINERS file directly. They

--- a/README.md
+++ b/README.md
@@ -197,4 +197,4 @@ Please use the [Flatcar issue tracker][bugs] to report all bugs, issues, and fea
 
 [semaphore]: http://en.wikipedia.org/wiki/Semaphore_(programming)
 [cas]: https://etcd.io/docs/v3.3.12/learning/api/#transaction
-[bugs]: https://github.com/kinvolk/flatcar/issues/new
+[bugs]: https://github.com/flatcar/flatcar/issues/new

--- a/locksmithctl/locksmithctl.go
+++ b/locksmithctl/locksmithctl.go
@@ -223,7 +223,7 @@ func getClient() (*lock.EtcdLockClient, error) {
 	// It has been shown in the CI (cl.locksmith.cluster) that etcd/v2 recent upgrade has broke the resiliency
 	// of the endpoint.
 	// It can be safely removed once the `etcd` V3 upgrade done.
-	// More details https://github.com/kinvolk/coreos-overlay/pull/1161#issuecomment-891906580.
+	// More details https://github.com/flatcar-archive/coreos-overlay/pull/1161#issuecomment-891906580 
 	for _, ep := range globalFlags.Endpoints {
 		cfg := client.Config{
 			Endpoints: []string{ep},


### PR DESCRIPTION
# [Title: Drop kinvolk references]

Updates `kinfolk` references to `Flatcar` where appropriate. I've left the one in `NOTICE` as I'm unsure if this should remain (both the reference and the file itself)

## How to use

No usage updates. Just updating documentation references

## Testing done

View documentation

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
