### PR TITLE
add dependabot to manage gha updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+## Reference: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "monday"


### PR DESCRIPTION
# [Title: manage GHA dependencies with dependabot]

This adds a configuration file similar to other Flatcar repositories so that dependabot manages updates to GHA dependencies.

## How to use

N/A. Dependabot will start running on a weekly cadence to bump GHA dependencies

## Testing done

N/A. Matching configurations from other Flatcar repositories.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
