### PR TITLE
fix(updateengine): return AddMatch error

### DIFF
--- a/updateengine/client.go
+++ b/updateengine/client.go
@@ -70,7 +70,7 @@ func New() (c *Client, err error) {
 
 	call := c.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match)
 	if call.Err != nil {
-		return nil, err
+		return nil, call.Err
 	}
 
 	c.ch = make(chan *dbus.Signal, signalBuffer)


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect error handling when registering the updateengine D-Bus signal match.

`updateengine.New()` currently checks `call.Err` after `AddMatch()`, but returns the earlier `err` variable instead. At this point `err` is nil because `Hello()` has already succeeded.

As a result, if `AddMatch()` fails, `New()` can return `(nil, nil)`. The caller checks the returned error and proceeds with the nil client, which can subsequently be dereferenced.

This change returns the actual `call.Err` to the caller.

## Testing done

- `go test ./...`
- `git diff --check`

All tests pass.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
