### PR TITLE
test(lock): fix SetMax test range

### DIFF
--- a/lock/semaphore_test.go
+++ b/lock/semaphore_test.go
@@ -227,7 +227,7 @@ func TestSetMax(t *testing.T) {
 	c.Init()
 	al := New("a", &c)
 	al.Lock()
-	for i := range []int{3, 2, 1, 0, -1, 0, 1, 2, 3} {
+	for _, i := range []int{3, 2, 1, 0, -1, 0, 1, 2, 3} {
 		al.SetMax(i)
 		if c.sem.Semaphore != i-1 {
 			t.Error("SetMax did not increment the semaphore", c.sem.Semaphore)


### PR DESCRIPTION
## What does this PR do?

Fixes the `TestSetMax` test in `lock/semaphore_test.go`.

The test defines an explicit sequence of values:

`3, 2, 1, 0, -1, 0, 1, 2, 3`

but uses a single variable `range`, which iterates over the slice indices rather than its values. As a result, the test actually passes `0, 1, 2, 3, 4, 5, 6, 7, 8` to `SetMax()` and never exercises the intended negative or decreasing values.

This changes the loop to use `for _, i := range ...`, so the test actually exercises the values it defines.

## Testing

- `go test ./lock`
- `git diff --check`

All tests pass.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
